### PR TITLE
Updated DiodeOrientation import

### DIFF
--- a/Firmware/code.py
+++ b/Firmware/code.py
@@ -5,7 +5,7 @@ import board
 
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.keys import KC
-from kmk.matrix import DiodeOrientation
+from kmk.scanners import DiodeOrientation
 from kmk.modules.layers import Layers
 from kmk.keys import KC, make_key
 #from kmk.consts import UnicodeMode


### PR DESCRIPTION
DiodeOrientation now resides in the "scanners" module.  The import has been updated to reflect that change.  Without this update the provided KMK firmware does not function on the Bolt Ind keyboard.